### PR TITLE
Fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Repowise
-Frontend to [repowise.com](repowise.com) a service that exposes frontend package sizes.
+Frontend to [repowise.com](https://repowise.com) a service that exposes frontend package sizes.


### PR DESCRIPTION
This link was being rendered as a relative link to the file `repowise.com` in this GitHub repository.